### PR TITLE
[Help request] Local variable outside of Disc::WorkerGroup was out of scope

### DIFF
--- a/bin/disc
+++ b/bin/disc
@@ -7,10 +7,9 @@ Clap.run ARGV,
   "-r" => lambda { |file| require file }
 
 if defined?(Celluloid)
-  concurrency = Integer(ENV.fetch('DISC_CONCURRENCY', '25'))
   $stdout.puts(
     "[Notice] Disc running in celluloid mode! Current DISC_CONCURRENCY is\
- #{ concurrency }."
+ #{ Integer(ENV.fetch('DISC_CONCURRENCY', '25')) }."
   )
 
   Disc::Worker.send(:include, Celluloid)
@@ -19,7 +18,7 @@ if defined?(Celluloid)
     # Deprecated as of Celluloid 0.17, but still supported via "backported mode"
     class Disc::WorkerGroup < Celluloid::SupervisionGroup
       pool Disc::Worker,
-            size: concurrency,
+            size: Integer(ENV.fetch('DISC_CONCURRENCY', '25')),
             as: :worker_pool,
             args: [{ run: true }]
     end
@@ -27,7 +26,7 @@ if defined?(Celluloid)
     Disc::WorkerGroup.run
   else
     Disc::Worker.pool(
-      size: concurrency,
+      size: Integer(ENV.fetch('DISC_CONCURRENCY', '25')),
       args: [{ run: true }]
     )
   end
@@ -35,3 +34,4 @@ else
   $stdout.puts("[Notice] Disc running in non-threaded mode")
   Disc::Worker.run
 end
+


### PR DESCRIPTION
Hi Pote,

I'm not sure if this is more of help request or a pull request.

I had tried to start Disc with the Rails/ActiveJob integration aspect of the readme.  The problem arose when I tried to run:

```bash
DISQUE_NODES=localhost:7711 QUEUES=urgent,default disc -r ./disc_init.rb

[Notice] Disc running in celluloid mode! Current DISC_CONCURRENCY is 25.
/Users/mzemel/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/disc-0.0.19/bin/disc:22:in `<class:WorkerGroup>': undefined local variable or method `concurrency' for Disc::WorkerGroup:Class (NameError)
	from /Users/mzemel/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/disc-0.0.19/bin/disc:20:in `<top (required)>'
	from /Users/mzemel/.rbenv/versions/2.1.2/bin/disc:23:in `load'
	from /Users/mzemel/.rbenv/versions/2.1.2/bin/disc:23:in `<main>'
````

In IRB, you cannot access a local variable defined out of the scope of a class, but you can reference a method.  However, in this case even a method or instance variable does not share scope with the internals of the `Disc::WorkerGroup` class (I tried a little hacking on it).  I assume this has to do with `method_missing` and details I do not fully grok.

```ruby
require 'disc'
require 'clap'

Clap.run ARGV,
  "-r" => lambda { |file| require file }

if defined?(Celluloid)
  concurrency = Integer(ENV.fetch('DISC_CONCURRENCY', '25'))
  $stdout.puts(
    "[Notice] Disc running in celluloid mode! Current DISC_CONCURRENCY is\
 #{ concurrency }."
  )

  Disc::Worker.send(:include, Celluloid)

  if defined?(Celluloid::SupervisionGroup)
    # Deprecated as of Celluloid 0.17, but still supported via "backported mode"
    class Disc::WorkerGroup < Celluloid::SupervisionGroup
      pool Disc::Worker,
            size: concurrency,
```
**Ex. 1** Failing code.

Using the code in the pull request, I was able to move past this error message.  However, I do not see any enqueued jobs from Rails showing up in my running `disc` process.

If anything stands out immediately as having been a problem on another machine and there's an easy solution, let me know because I'd love to try out Disc/Disque.  Please do not merge this PR as it has not fixed my issue.