### PR TITLE
Use connection_pool as a dumb thread pool instead of Celluloid

### DIFF
--- a/bin/disc
+++ b/bin/disc
@@ -6,32 +6,4 @@ require 'clap'
 Clap.run ARGV,
   "-r" => lambda { |file| require file }
 
-if defined?(Celluloid)
-  $stdout.puts(
-    "[Notice] Disc running in celluloid mode! Current DISC_CONCURRENCY is\
- #{ Integer(ENV.fetch('DISC_CONCURRENCY', '25')) }."
-  )
-
-  Disc::Worker.send(:include, Celluloid)
-
-  if defined?(Celluloid::SupervisionGroup)
-    # Deprecated as of Celluloid 0.17, but still supported via "backported mode"
-    class Disc::WorkerGroup < Celluloid::SupervisionGroup
-      pool Disc::Worker,
-            size: Integer(ENV.fetch('DISC_CONCURRENCY', '25')),
-            as: :worker_pool,
-            args: [{ run: true }]
-    end
-
-    Disc::WorkerGroup.run
-  else
-    Disc::Worker.pool(
-      size: Integer(ENV.fetch('DISC_CONCURRENCY', '25')),
-      args: [{ run: true }]
-    )
-  end
-else
-  $stdout.puts("[Notice] Disc running in non-threaded mode")
-  Disc::Worker.run
-end
-
+Disc::Worker.run


### PR DESCRIPTION
Instead of depending on Celluloid, which is complex and way too much for what we actually nead, this sets up a ConnectionPool that checks out nothing (i.e. the connections are just `true`), so that we can abuse it as a thread pool.

This would _always_ make the workers threaded (set `DISC_CONCURRENCY=1` if you want a single thread...).

Having a single code path is good, though. It means it's simpler to test features / bugfixes as we don't need to run every test by duplicate on threaded/nonthreaded mode.

Oh, and speaking about tests, did I mention this is just a WIP? :P

cc @pote 