### PR TITLE
Update MAXLEN test, now that disque bug is fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - gems
 before_install:
   - test -d disque/.git || git clone -n https://github.com/antirez/disque.git
-  - cd disque && git fetch origin && git checkout -f master && make && cd ..
+  - cd disque && git fetch origin && git checkout -f origin/master && make && cd ..
 install:
   - export GEM_HOME=$PWD/gems/$RUBY_VERSION
   - export GEM_PATH=$GEM_HOME:$GEM_PATH

--- a/test/disc_test.rb
+++ b/test/disc_test.rb
@@ -177,8 +177,6 @@ scope do
 
   test 'enqueue supports maxlen' do
     Echoer.enqueue(['one argument', { random: 'data' }, 3], maxlen: 1)
-    # disque off by-one bug? see: https://github.com/antirez/disque/issues/109
-    Echoer.enqueue(['one argument', { random: 'data' }, 3], maxlen: 1)
     error = Echoer.enqueue(['one argument', { random: 'data' }, 3], maxlen: 1) rescue $!
 
     assert_equal RuntimeError, error.class


### PR DESCRIPTION
The test for MAXLEN emulated the wrong behavior in disque, caused by an off-by-one check. Now that antirez/disque#109 is fixed, we need to remove this workaround.