### PR TITLE
Add possibility to use msgpack >= 0.5.0.

### DIFF
--- a/disc.gemspec
+++ b/disc.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.executables.push('disc')
 
   s.add_dependency('disque', '~> 0.0.6')
-  s.add_dependency('msgpack', '~> 0.6.1')
+  s.add_dependency('msgpack', '>= 0.5.0', '< 0.7')
   s.add_dependency('clap', '~> 1.0')
 end


### PR DESCRIPTION
Right now we can't use ohm and disc together. More information: https://github.com/soveran/ohm/pull/195