### PR TITLE
Fix gemspec

### DIFF
--- a/.gems
+++ b/.gems
@@ -1,5 +1,5 @@
 cutest -v 1.2.2
 byebug -v 5.0.0
 disque -v 0.0.6
-msgpack -v 0.6.1
+msgpack -v 0.6.2
 celluloid -v 0.17.0

--- a/disc.gemspec
+++ b/disc.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.executables.push('disc')
 
   s.add_dependency('disque', '~> 0.0.6')
-  s.add_dependency('msgpack', '>= 0.5.6', '=< 0.6.2')
+  s.add_dependency('msgpack', '>= 0.5.6', '< 0.6.3')
   s.add_dependency('clap', '~> 1.0')
 end


### PR DESCRIPTION
I couldn't find the pattern here: http://guides.rubygems.org/patterns/

This is the error:

```
There was a Gem::Requirement::BadRequirementError while loading disc.gemspec:
Illformed requirement ["=< 0.6.2"] from
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/disc-db46513e0e96/disc.gemspec:17:in `block in <main>'
```

I also upgraded the version of msgpack in development.