### PR TITLE
Stateful Jobs

### DIFF
--- a/lib/disc.rb
+++ b/lib/disc.rb
@@ -165,6 +165,10 @@ class Disc
         @queue || Disc.default_queue
       end
 
+      def perform(arguments)
+        self.new.perform(*arguments)
+      end
+
       def enqueue(args = [], at: nil, queue: nil, **options)
         options = disc_options.merge(options).tap do |opt|
           opt[:delay] = at.to_time.to_i - DateTime.now.to_time.to_i unless at.nil?

--- a/lib/disc.rb
+++ b/lib/disc.rb
@@ -33,6 +33,10 @@ class Disc
     @default_queue = queue
   end
 
+  def self.qlen(queue)
+    disque.call('QLEN', queue)
+  end
+
   def self.flush
     Disc.disque.call('DEBUG', 'FLUSHALL')
   end

--- a/lib/disc.rb
+++ b/lib/disc.rb
@@ -100,6 +100,7 @@ class Disc
             instance = Object.const_get(job['class']).new
             instance.perform(*job['arguments'])
             disque.call('ACKJOB', msgid)
+            $stdout.puts("Completed #{job['class']} id #{msgid}")
           rescue => err
             Disc.on_error(err, job.update('id' => msgid, 'queue' => queue))
           end

--- a/test/disc_test.rb
+++ b/test/disc_test.rb
@@ -93,6 +93,12 @@ scope do
     assert_equal 'one argument', job.arguments.first
   end
 
+  test 'we can query the lenght of a given queue' do
+    job_instance = Echoer.enqueue(['one argument', { random: 'data' }, 3])
+
+    assert_equal 1, Disc.qlen(Echoer.queue)
+  end
+
   test 'enqueue at timestamp behaves properly' do
     job_instance = Echoer.enqueue(['one argument', { random: 'data' }, 3], at: Time.now + 1)
 


### PR DESCRIPTION
I've been thinking about this for some time, Disque provides an api to access information about a job given it's id, which includes the state of the job (queued, etc), so I thought it'd be nice to expose that.

Would like some feedback on it before merging. :)