### PR TITLE
Use json (standard library) to serialize jobs

### DIFF
--- a/.gems
+++ b/.gems
@@ -1,5 +1,4 @@
 cutest:1.2.2
 byebug:5.0.0
 disque:0.0.6
-msgpack:0.6.2
 celluloid:0.17.0

--- a/disc.gemspec
+++ b/disc.gemspec
@@ -14,6 +14,5 @@ Gem::Specification.new do |s|
   s.executables.push('disc')
 
   s.add_dependency('disque', '~> 0.0.6')
-  s.add_dependency('msgpack', '>= 0.5.6', '< 0.6.3')
   s.add_dependency('clap', '~> 1.0')
 end

--- a/test/disc_test.rb
+++ b/test/disc_test.rb
@@ -1,6 +1,5 @@
 require 'cutest'
 require 'disc'
-require 'msgpack'
 require 'pty'
 require 'timeout'
 
@@ -62,7 +61,7 @@ scope do
     assert_equal 1, jobs.count
 
     jobs.first.tap do |queue, id, serialized_job|
-      job = MessagePack.unpack(serialized_job)
+      job = Disc.deserialize(serialized_job)
 
       assert job.has_key?('class')
       assert job.has_key?('arguments')
@@ -117,7 +116,7 @@ scope do
     jobs.first.tap do |queue, id, serialized_job|
       assert_equal 'test', queue
       assert_equal job_instance.disque_id, id
-      job = MessagePack.unpack(serialized_job)
+      job = Disc.deserialize(serialized_job)
       assert job.has_key?('class')
       assert job.has_key?('arguments')
       assert_equal 'Echoer', job['class']


### PR DESCRIPTION
Allow some flexibility for the user on serialization strategy by overriding `Disc.serialize` and `Disc.deserialize`.

Ohm has moved to using json because of compatibility problems across versions of messagepack, I myself have found messagepack cumbersome, and also a completely avoidable external dependency.

I think that using the standard library json implementation as a default is okay, with the added flexibility of overriding the serialization strategy to whatever a user needs.

@foca thoughts?
